### PR TITLE
Fix bugs in samplers

### DIFF
--- a/Source/Modules/app_view_models/Edit/Plugins/Sampler/DrumSamplerViewModel.cpp
+++ b/Source/Modules/app_view_models/Edit/Plugins/Sampler/DrumSamplerViewModel.cpp
@@ -8,9 +8,10 @@ DrumSamplerViewModel::DrumSamplerViewModel(
     itemListState.listSize = drumKitNames.size();
 
     if (drumKitNames.size() > 0) {
+        DBG("current kit index: " +
+            std::to_string(itemListState.getSelectedItemIndex()));
         juce::File currentMap = mapFiles[itemListState.getSelectedItemIndex()];
-        readMappingFileIntoSampler(currentMap,
-                                   samplerPlugin->getNumSounds() <= 0);
+        readMappingFileIntoSampler(currentMap, true);
         DBG("updating thumb");
         updateThumb();
     }
@@ -52,6 +53,10 @@ void DrumSamplerViewModel::valueTreePropertyChanged(
 void DrumSamplerViewModel::readMappingFileIntoSampler(
     const juce::File &mappingFile, bool shouldUpdateSounds) {
     drumSampleFiles.clear();
+    for (int i = 0; i < samplerPlugin->getNumSounds(); i++) {
+        samplerPlugin->removeSound(i);
+    }
+
     YAML::Node rootNode =
         YAML::LoadFile(mappingFile.getFullPathName().toStdString());
     const auto kitDir =

--- a/Source/Modules/app_view_models/Edit/Plugins/Sampler/SynthSamplerViewModel.cpp
+++ b/Source/Modules/app_view_models/Edit/Plugins/Sampler/SynthSamplerViewModel.cpp
@@ -27,13 +27,14 @@ SynthSamplerViewModel::SynthSamplerViewModel(
         jassert(error.isEmpty());
     }
 
-    const auto file = files[0];
+    const auto file = files[itemListState.getSelectedItemIndex()];
     auto *reader = formatManager.createReaderFor(file);
     if (reader != nullptr) {
         // This must be set in order for the plugin state to be loaded in
         // correctly if the sound already existed (ie the number of sounds was >
         // 0)
-        samplerPlugin->setSoundMedia(0, file.getFullPathName());
+        samplerPlugin->setSoundMedia(selectedSoundIndex.get(),
+                                     file.getFullPathName());
 
         std::unique_ptr<juce::AudioFormatReaderSource> newSource(
             new juce::AudioFormatReaderSource(reader, true));


### PR DESCRIPTION
Fix issue with sampler state not initializing correctly when switching from and back to a track. Also fixed issue with drum kit sample sounds not being cleared. 