### PR TITLE
Init midi devices on timer, allow hotswap

### DIFF
--- a/Source/Modules/app_services/MidiCommandManager/MidiCommandManager.cpp
+++ b/Source/Modules/app_services/MidiCommandManager/MidiCommandManager.cpp
@@ -3,30 +3,33 @@
 namespace app_services {
 
 MidiCommandManager::MidiCommandManager(tracktion::Engine &e) : engine(e) {
-    startTimer (500);
+    startTimer(500);
 }
 
-void MidiCommandManager::timerCallback()
-{
+void MidiCommandManager::timerCallback() {
     auto &juceDeviceManager = engine.getDeviceManager().deviceManager;
     auto newMidiDevices = juce::MidiInput::getAvailableDevices();
 
     if (newMidiDevices != lastMidiDevices) {
-        for (auto& oldDevice : lastMidiDevices) {
+        for (auto &oldDevice : lastMidiDevices) {
             if (!newMidiDevices.contains(oldDevice)) {
-                juceDeviceManager.setMidiInputDeviceEnabled(oldDevice.identifier, false);
-                juceDeviceManager.removeMidiInputDeviceCallback(oldDevice.identifier,
-                                                                this);
-                juce::Logger::writeToLog("disbling juce midi device: " + oldDevice.name);
+                juceDeviceManager.setMidiInputDeviceEnabled(
+                    oldDevice.identifier, false);
+                juceDeviceManager.removeMidiInputDeviceCallback(
+                    oldDevice.identifier, this);
+                juce::Logger::writeToLog("disbling juce midi device: " +
+                                         oldDevice.name);
             }
         }
 
-        for (auto& newDevice : newMidiDevices) {
+        for (auto &newDevice : newMidiDevices) {
             if (!lastMidiDevices.contains(newDevice)) {
-                juceDeviceManager.setMidiInputDeviceEnabled(newDevice.identifier, true);
-                juceDeviceManager.addMidiInputDeviceCallback(newDevice.identifier,
-                                                             this);
-                juce::Logger::writeToLog("enabling juce midi device: " + newDevice.name);
+                juceDeviceManager.setMidiInputDeviceEnabled(
+                    newDevice.identifier, true);
+                juceDeviceManager.addMidiInputDeviceCallback(
+                    newDevice.identifier, this);
+                juce::Logger::writeToLog("enabling juce midi device: " +
+                                         newDevice.name);
             }
         }
 

--- a/Source/Modules/app_services/MidiCommandManager/MidiCommandManager.h
+++ b/Source/Modules/app_services/MidiCommandManager/MidiCommandManager.h
@@ -1,7 +1,7 @@
 #pragma once
 namespace app_services {
 
-class MidiCommandManager : private juce::MidiInputCallback {
+class MidiCommandManager : private juce::MidiInputCallback, private juce::Timer {
   public:
     explicit MidiCommandManager(tracktion::Engine &e);
     ~MidiCommandManager() override;
@@ -13,6 +13,8 @@ class MidiCommandManager : private juce::MidiInputCallback {
     bool isMinusDown = false;
     void midiMessageReceived(const juce::MidiMessage &message,
                              const juce::String &source);
+
+    void timerCallback() override;
 
     class Listener {
       public:
@@ -143,6 +145,7 @@ class MidiCommandManager : private juce::MidiInputCallback {
     tracktion::Engine &engine;
     juce::Component *focusedComponent;
     juce::ListenerList<Listener> listeners;
+    juce::Array<juce::MidiDeviceInfo> lastMidiDevices;
 
     // This is used to dispach an incoming message to the message thread
     class IncomingMessageCallback : public juce::CallbackMessage {

--- a/Source/Modules/app_services/MidiCommandManager/MidiCommandManager.h
+++ b/Source/Modules/app_services/MidiCommandManager/MidiCommandManager.h
@@ -1,7 +1,8 @@
 #pragma once
 namespace app_services {
 
-class MidiCommandManager : private juce::MidiInputCallback, private juce::Timer {
+class MidiCommandManager : private juce::MidiInputCallback,
+                           private juce::Timer {
   public:
     explicit MidiCommandManager(tracktion::Engine &e);
     ~MidiCommandManager() override;


### PR DESCRIPTION
## Please fill in this pull request template before submitting

### 1. Description
Allow MidiCommandManager to poll for connected and disconnected devices
This allows timing issues to be negated and teensy and host device and start in any order.
Whist I was debugging issues on he android I ran into this problem,

### 2. Fill in checklist by marking [x]
- [X] I've read the CONTRIBUTING.md
- [X] My code is formatted using required linting
- [X] I've run my code locally and checked it works
- [-] My code has unit tests associated with it (if applicable)
- [X] I've run the test suite locally and all tests pass