### PR TITLE
Add “Load / Save” feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ cmake-build-debug/
 cmake-build-release/
 
 
+*.vsidx
+.vs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ juce_add_gui_app(LMN-3
     # DOCUMENT_EXTENSIONS ...           # Specify file extensions that should be associated with this app
     # COMPANY_NAME ...                  # Specify the name of the app's author
     PRODUCT_NAME LMN-3         # The name of the final executable, which can differ from the target name
-)      
+)
 
 target_compile_features(LMN-3  PRIVATE cxx_std_17)
 
@@ -37,6 +37,7 @@ target_sources(LMN-3  PRIVATE
     Source/Views/LookAndFeel/ListItems/ListItemColour2LookAndFeel.cpp
     Source/Views/Edit/Settings/SettingsListView.cpp
     Source/Views/Edit/Settings/DeviceTypeListView.cpp
+    Source/Views/Edit/Settings/LoadSaveSongListView.cpp
     Source/Views/Edit/Settings/OutputListView.cpp
     Source/Views/Edit/Settings/SampleRateListView.cpp
     Source/Views/Edit/Settings/MidiInputListView.cpp
@@ -198,5 +199,3 @@ target_link_libraries(LMN-3
         juce::juce_recommended_lto_flags
         juce::juce_recommended_warning_flags
 )
-
-

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,22 @@
+﻿{
+	"configurations": [
+		{
+			"name": "x64-Debug",
+			"generator": "Ninja",
+			"configurationType": "Debug",
+			"inheritEnvironments": [ "msvc_x64_x64" ],
+			"buildRoot": "${projectDir}\\out\\build\\${name}",
+			"installRoot": "${projectDir}\\out\\install\\${name}",
+			"cmakeCommandArgs": "",
+			"buildCommandArgs": "",
+			"ctestCommandArgs": "",
+			"variables": [
+				{
+					"name": "YAML_BUILD_SHARED_LIBS",
+					"value": "True",
+					"type": "BOOL"
+				}
+			]
+		}
+	]
+}

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -1,12 +1,12 @@
+#include "App.h"
+#include "AppLookAndFeel.h"
+#include "ExtendedUIBehaviour.h"
 #include <ImageData.h>
 #include <app_configuration/app_configuration.h>
 #include <app_services/app_services.h>
 #include <internal_plugins/internal_plugins.h>
 #include <memory>
 #include <tracktion_engine/tracktion_engine.h>
-#include "App.h"
-#include "ExtendedUIBehaviour.h"
-#include "AppLookAndFeel.h"
 
 class GuiAppApplication : public juce::JUCEApplication {
   public:
@@ -14,7 +14,7 @@ class GuiAppApplication : public juce::JUCEApplication {
         return *dynamic_cast<GuiAppApplication *>(
             JUCEApplication::getInstance());
     }
-      GuiAppApplication()
+    GuiAppApplication()
         : splash(new juce::SplashScreen(
               "Welcome to my LMN-3!",
               juce::ImageFileFormat::loadFrom(
@@ -46,8 +46,6 @@ class GuiAppApplication : public juce::JUCEApplication {
         engine.getPluginManager()
             .createBuiltInType<internal_plugins::DrumSamplerPlugin>();
 
-
-
         // this can cache all your plugins.
         /* auto &knownPluginList = engine.getPluginManager().knownPluginList;
 
@@ -69,9 +67,6 @@ class GuiAppApplication : public juce::JUCEApplication {
             tracktion::ExternalPlugin::xmlTypeName,
             *pluginDescriptions.getLast());
             */
-        
-
-
 
         auto userAppDataDirectory = juce::File::getSpecialLocation(
             juce::File::userApplicationDataDirectory);
@@ -118,11 +113,8 @@ class GuiAppApplication : public juce::JUCEApplication {
             auto seconds =
                 juce::String(currentTime.getSeconds()).paddedLeft('0', 2);
 
-
-
             juce::String newEditFileName = "edit_" + day + month + year +
                                            hours + minutes + seconds + ".xml";
-
 
             auto editFile = savedDirectory.getChildFile(newEditFileName);
 
@@ -130,7 +122,8 @@ class GuiAppApplication : public juce::JUCEApplication {
             // Crear el archivo y la edición
             editFile.create();
             edit = tracktion::createEmptyEdit(engine, editFile);
-            edit->ensureNumberOfAudioTracks(tracktion::getAudioTracks(*edit).size());
+            edit->ensureNumberOfAudioTracks(
+                tracktion::getAudioTracks(*edit).size());
 
             for (auto track : tracktion::getAudioTracks(*edit))
                 track->setColour(appLookAndFeel.getRandomColour());
@@ -198,11 +191,10 @@ class GuiAppApplication : public juce::JUCEApplication {
 
         juce::Logger::writeToLog("end nullptr");
 
-        //restartApplication();
+        // restartApplication();
 
-        //juce::Logger::writeToLog("Restarted ok");
+        // juce::Logger::writeToLog("Restarted ok");
     }
-    
 
     void systemRequestedQuit() override {
         // This is called when the app is being asked to quit: you can ignore
@@ -216,7 +208,7 @@ class GuiAppApplication : public juce::JUCEApplication {
 
         juce::ChildProcess process;
         process.start(currentExecutable.getFullPathName());
-        //quit();
+        // quit();
     }
     void anotherInstanceStarted(const juce::String &commandLine) override {
         // When another instance of the app is launched while this one is

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -4,18 +4,19 @@
 #include <internal_plugins/internal_plugins.h>
 #include <memory>
 #include <tracktion_engine/tracktion_engine.h>
-//#include <SynthSampleData.h>
-//#include <DrumSampleData.h>
 #include "App.h"
 #include "ExtendedUIBehaviour.h"
-
 #include "AppLookAndFeel.h"
 
 class GuiAppApplication : public juce::JUCEApplication {
   public:
-    GuiAppApplication()
+    static GuiAppApplication &getInstance() {
+        return *dynamic_cast<GuiAppApplication *>(
+            JUCEApplication::getInstance());
+    }
+      GuiAppApplication()
         : splash(new juce::SplashScreen(
-              "Welcome to my app!",
+              "Welcome to my LMN-3!",
               juce::ImageFileFormat::loadFrom(
                   ImageData::tracktion_engine_powered_png,
                   ImageData::tracktion_engine_powered_pngSize),
@@ -45,22 +46,95 @@ class GuiAppApplication : public juce::JUCEApplication {
         engine.getPluginManager()
             .createBuiltInType<internal_plugins::DrumSamplerPlugin>();
 
+
+
+        // this can cache all your plugins.
+        /* auto &knownPluginList = engine.getPluginManager().knownPluginList;
+
+        // the plugin needs to be exists
+        juce::File pluginFile("~/.vst3/TAL-NoiseMaker/TAL-NoiseMaker.vst3");
+
+        // these will be filled by the next function, so we get the
+        // pluginDescription
+        static juce::OwnedArray<juce::PluginDescription> pluginDescriptions;
+        static juce::VST3PluginFormat vst3PluginFormat;
+
+        // now you can add your plugin to the knownPluginList
+        knownPluginList.scanAndAddFile(
+            juce::String(pluginFile.getFullPathName()), true,
+            pluginDescriptions, vst3PluginFormat);
+
+        // get the plugin
+        auto plug = edit->getPluginCache().createNewPlugin(
+            tracktion::ExternalPlugin::xmlTypeName,
+            *pluginDescriptions.getLast());
+            */
+        
+
+
+
         auto userAppDataDirectory = juce::File::getSpecialLocation(
             juce::File::userApplicationDataDirectory);
-        juce::File editFile =
+        juce::File savedDirectory =
             userAppDataDirectory.getChildFile(getApplicationName())
-                .getChildFile("edit");
-        if (editFile.existsAsFile()) {
-            edit = tracktion::loadEditFromFile(engine, editFile);
+                .getChildFile("load_project");
+
+        if (!savedDirectory.exists()) {
+            savedDirectory.createDirectory();
+        }
+
+        juce::File latestFile;
+        juce::Time latestModificationTime;
+
+        if (savedDirectory.isDirectory()) {
+            juce::Array<juce::File> files = savedDirectory.findChildFiles(
+                juce::File::findFiles, false, "*.xml");
+
+            for (const auto &currentFile : files) {
+                if (currentFile.getLastModificationTime() >
+                    latestModificationTime) {
+                    latestModificationTime =
+                        currentFile.getLastModificationTime();
+                    latestFile = currentFile;
+                }
+            }
+        }
+
+        if (latestFile.existsAsFile()) {
+            edit = tracktion::loadEditFromFile(engine, latestFile);
+            ConfigurationHelpers::setSavedTrackName(latestFile);
         } else {
+            // Generar nombre de archivo basado en la fecha actual
+            auto currentTime = juce::Time::getCurrentTime();
+            auto day =
+                juce::String(currentTime.getDayOfMonth()).paddedLeft('0', 2);
+            auto month = juce::String(currentTime.getMonth() + 1)
+                             .paddedLeft('0', 2); // Meses son 0-based
+            auto year = juce::String(currentTime.getYear());
+            auto hours =
+                juce::String(currentTime.getHours()).paddedLeft('0', 2);
+            auto minutes =
+                juce::String(currentTime.getMinutes()).paddedLeft('0', 2);
+            auto seconds =
+                juce::String(currentTime.getSeconds()).paddedLeft('0', 2);
+
+
+
+            juce::String newEditFileName = "edit_" + day + month + year +
+                                           hours + minutes + seconds + ".xml";
+
+
+            auto editFile = savedDirectory.getChildFile(newEditFileName);
+
+            ConfigurationHelpers::setSavedTrackName(editFile);
+            // Crear el archivo y la edición
             editFile.create();
             edit = tracktion::createEmptyEdit(engine, editFile);
-            edit->ensureNumberOfAudioTracks(8);
+            edit->ensureNumberOfAudioTracks(tracktion::getAudioTracks(*edit).size());
 
             for (auto track : tracktion::getAudioTracks(*edit))
                 track->setColour(appLookAndFeel.getRandomColour());
         }
-
         ConfigurationHelpers::initSamples(engine);
 
         // The master track does not have the default  plugins added to it by
@@ -92,6 +166,7 @@ class GuiAppApplication : public juce::JUCEApplication {
         initialiseAudioDevices();
         mainWindow = std::make_unique<MainWindow>(getApplicationName(), engine,
                                                   *edit, *midiCommandManager);
+
         splash->deleteAfterDelay(juce::RelativeTime::seconds(4.25), false);
     }
 
@@ -104,11 +179,10 @@ class GuiAppApplication : public juce::JUCEApplication {
                 "Attempt to initialise default devices failed!");
         }
     }
-
     void shutdown() override {
         // Add your application's shutdown code here..
-
-        bool success = edit->engine.getTemporaryFileManager()
+        juce::Logger::writeToLog("Shutdown call");
+        /* bool success = edit->engine.getTemporaryFileManager()
                            .getTempDirectory()
                            .deleteRecursively();
         if (!success) {
@@ -116,10 +190,19 @@ class GuiAppApplication : public juce::JUCEApplication {
                                      edit->engine.getTemporaryFileManager()
                                          .getTempDirectory()
                                          .getFullPathName());
-        }
+        }*/
+        juce::Logger::writeToLog("init nullptr");
+
         juce::Logger::setCurrentLogger(nullptr);
         mainWindow = nullptr; // (deletes our window)
+
+        juce::Logger::writeToLog("end nullptr");
+
+        //restartApplication();
+
+        //juce::Logger::writeToLog("Restarted ok");
     }
+    
 
     void systemRequestedQuit() override {
         // This is called when the app is being asked to quit: you can ignore
@@ -127,7 +210,14 @@ class GuiAppApplication : public juce::JUCEApplication {
         // allow the app to close.
         quit();
     }
+    void restartApplication() {
+        juce::File currentExecutable(
+            juce::File::getSpecialLocation(juce::File::currentExecutableFile));
 
+        juce::ChildProcess process;
+        process.start(currentExecutable.getFullPathName());
+        //quit();
+    }
     void anotherInstanceStarted(const juce::String &commandLine) override {
         // When another instance of the app is launched while this one is
         // running, this method is invoked, and the commandLine parameter tells

--- a/Source/Modules/app_configuration/ConfigurationHelpers.cpp
+++ b/Source/Modules/app_configuration/ConfigurationHelpers.cpp
@@ -1,6 +1,5 @@
 #include "ConfigurationHelpers.h"
 #include <yaml-cpp/yaml.h>
-#include "ConfigurationHelpers.h"
 
 juce::File ConfigurationHelpers::SAVED_TRACK_NAME;
 
@@ -12,10 +11,9 @@ juce::File ConfigurationHelpers::getSavedTrackName() {
     return SAVED_TRACK_NAME;
 }
 
-juce::String ConfigurationHelpers::getApplicationName(){
+juce::String ConfigurationHelpers::getApplicationName() {
     return ROOT_DIRECTORY_NAME;
 }
-
 
 bool ConfigurationHelpers::writeBinarySamplesToDirectory(
     const juce::File &destDir, juce::StringRef filename, const char *data,
@@ -176,7 +174,6 @@ double ConfigurationHelpers::getHeight(juce::File &configFile) {
     // Default to 480
     return 480;
 }
-
 
 juce::File ConfigurationHelpers::getSamplesDirectory() {
     auto userAppDataDirectory = juce::File::getSpecialLocation(

--- a/Source/Modules/app_configuration/ConfigurationHelpers.cpp
+++ b/Source/Modules/app_configuration/ConfigurationHelpers.cpp
@@ -1,5 +1,21 @@
 #include "ConfigurationHelpers.h"
 #include <yaml-cpp/yaml.h>
+#include "ConfigurationHelpers.h"
+
+juce::File ConfigurationHelpers::SAVED_TRACK_NAME;
+
+void ConfigurationHelpers::setSavedTrackName(const juce::File &newValue) {
+    SAVED_TRACK_NAME = newValue;
+}
+
+juce::File ConfigurationHelpers::getSavedTrackName() {
+    return SAVED_TRACK_NAME;
+}
+
+juce::String ConfigurationHelpers::getApplicationName(){
+    return ROOT_DIRECTORY_NAME;
+}
+
 
 bool ConfigurationHelpers::writeBinarySamplesToDirectory(
     const juce::File &destDir, juce::StringRef filename, const char *data,
@@ -160,6 +176,7 @@ double ConfigurationHelpers::getHeight(juce::File &configFile) {
     // Default to 480
     return 480;
 }
+
 
 juce::File ConfigurationHelpers::getSamplesDirectory() {
     auto userAppDataDirectory = juce::File::getSpecialLocation(

--- a/Source/Modules/app_configuration/ConfigurationHelpers.h
+++ b/Source/Modules/app_configuration/ConfigurationHelpers.h
@@ -9,7 +9,6 @@ class ConfigurationHelpers {
     static inline const juce::String DRUM_KITS_DIRECTORY_NAME = "drum_kits";
     static juce::File SAVED_TRACK_NAME;
 
- 
     static juce::File getSamplesDirectory();
     static juce::File getDrumKitsDirectory();
     static juce::File getTempSamplesDirectory(tracktion::Engine &engine);
@@ -17,13 +16,14 @@ class ConfigurationHelpers {
     static void initSamples(tracktion::Engine &engine);
     static bool getShowTitleBar(juce::File &configFile);
     static double getWidth(juce::File &configFile);
-    static double getHeight(juce::File &configFile);    
-    static void setSavedTrackName(const juce::File &newValue); // Declaración del método
+    static double getHeight(juce::File &configFile);
+    static void
+    setSavedTrackName(const juce::File &newValue); // Declaración del método
     static juce::File getSavedTrackName();         // Declaración del método
-    static juce::String getApplicationName(); // Declaración del método
+    static juce::String getApplicationName();      // Declaración del método
 
   private:
-      static bool writeBinarySamplesToDirectory(const juce::File &destDir,
+    static bool writeBinarySamplesToDirectory(const juce::File &destDir,
                                               juce::StringRef filename,
                                               const char *data,
                                               int dataSizeInBytes);
@@ -36,5 +36,4 @@ class ConfigurationHelpers {
                                 const juce::File &tempDrumDir);
     static juce::File createTempDirectory(tracktion::Engine &engine,
                                           const juce::String &folderName);
-
 };

--- a/Source/Modules/app_configuration/ConfigurationHelpers.h
+++ b/Source/Modules/app_configuration/ConfigurationHelpers.h
@@ -7,6 +7,9 @@ class ConfigurationHelpers {
     static inline const juce::String ROOT_DIRECTORY_NAME = "LMN-3";
     static inline const juce::String SAMPLES_DIRECTORY_NAME = "samples";
     static inline const juce::String DRUM_KITS_DIRECTORY_NAME = "drum_kits";
+    static juce::File SAVED_TRACK_NAME;
+
+ 
     static juce::File getSamplesDirectory();
     static juce::File getDrumKitsDirectory();
     static juce::File getTempSamplesDirectory(tracktion::Engine &engine);
@@ -14,10 +17,13 @@ class ConfigurationHelpers {
     static void initSamples(tracktion::Engine &engine);
     static bool getShowTitleBar(juce::File &configFile);
     static double getWidth(juce::File &configFile);
-    static double getHeight(juce::File &configFile);
+    static double getHeight(juce::File &configFile);    
+    static void setSavedTrackName(const juce::File &newValue); // Declaración del método
+    static juce::File getSavedTrackName();         // Declaración del método
+    static juce::String getApplicationName(); // Declaración del método
 
   private:
-    static bool writeBinarySamplesToDirectory(const juce::File &destDir,
+      static bool writeBinarySamplesToDirectory(const juce::File &destDir,
                                               juce::StringRef filename,
                                               const char *data,
                                               int dataSizeInBytes);
@@ -30,4 +36,5 @@ class ConfigurationHelpers {
                                 const juce::File &tempDrumDir);
     static juce::File createTempDirectory(tracktion::Engine &engine,
                                           const juce::String &folderName);
+
 };

--- a/Source/Modules/app_services/MidiCommandManager/MidiCommandManager.cpp
+++ b/Source/Modules/app_services/MidiCommandManager/MidiCommandManager.cpp
@@ -32,6 +32,7 @@ MidiCommandManager::~MidiCommandManager() {
 }
 
 void MidiCommandManager::setFocusedComponent(juce::Component *c) {
+    jassert(c != nullptr);
     focusedComponent = c;
 }
 

--- a/Source/Modules/app_view_models/Edit/Settings/LoadSaveSongListViewModel.cpp
+++ b/Source/Modules/app_view_models/Edit/Settings/LoadSaveSongListViewModel.cpp
@@ -1,0 +1,85 @@
+#include "LoadSaveSongListViewModel.h"
+
+namespace app_view_models {
+
+LoadSaveSongListViewModel::LoadSaveSongListViewModel(
+    tracktion::Edit &e, juce::AudioDeviceManager &dm,
+    const juce::String &appName)
+    : deviceManager(dm), state(e.state.getOrCreateChildWithName(
+                             IDs::LOAD_SAVE_SONG_VIEW_STATE, nullptr)),
+      itemListState(state, songNames.size()) {
+
+    auto userAppDataDirectory = juce::File::getSpecialLocation(
+        juce::File::userApplicationDataDirectory);
+    juce::File savedDirectory =
+        userAppDataDirectory.getChildFile(appName)
+            .getChildFile("saved");
+    
+    loadSongList(savedDirectory);
+    itemListState.addListener(this);
+}
+
+LoadSaveSongListViewModel::~LoadSaveSongListViewModel() {
+    itemListState.removeListener(this);
+}
+
+juce::StringArray LoadSaveSongListViewModel::getItemNames() {
+    return songNames;
+}
+
+juce::String LoadSaveSongListViewModel::getSelectedItem() {
+    return songNames[itemListState.getSelectedItemIndex()];
+}
+
+void LoadSaveSongListViewModel::selectedIndexChanged(int newIndex) {
+    // Aquí puedes añadir la lógica que necesites cuando cambie el índice
+    // seleccionado
+}
+
+void LoadSaveSongListViewModel::loadSongList(const juce::File &directory) {
+    songNames.clear();
+    songNames.add("Add");   
+
+    juce::Array<juce::File> songFiles =
+        directory.findChildFiles(juce::File::findFiles, false, "*.xml");
+
+    for (const auto &file : songFiles) {
+        songNames.add(file.getFileNameWithoutExtension());
+    }
+
+    itemListState.listSize = songNames.size();
+    itemListState.setSelectedItemIndex(
+        0); // Opcional: Resetear al primer ítem o cualquier otra lógica que
+            // necesites
+    itemListState.addListener(this);
+}
+void saveEditState(const tracktion::engine::Edit &edit,
+                   const juce::File &file) {
+    // Serializar el estado del Edit a XML
+    auto xml = edit.state.createXml();
+
+    // Guardar el XML en un archivo
+    if (xml) {
+        if (!xml->writeTo(file)) {
+            // Manejar el error si la escritura al archivo falla
+            DBG("Failed to write Edit state to file.");
+        }
+    } else {
+        // Manejar el error si la serialización falla
+        DBG("Failed to create XML from Edit state.");
+    }
+}
+void loadEditState(tracktion::engine::Edit &edit, const juce::File &file) {
+    // Leer el XML desde el archivo
+    auto xml = juce::XmlDocument::parse(file);
+
+    if (xml) {
+        // Deserializar el XML para restaurar el estado del Edit
+        edit.state = juce::ValueTree::fromXml(*xml);
+    } else {
+        // Manejar el error si la lectura del archivo falla
+        DBG("Failed to read Edit state from file.");
+    }
+}
+
+} // namespace app_view_models

--- a/Source/Modules/app_view_models/Edit/Settings/LoadSaveSongListViewModel.cpp
+++ b/Source/Modules/app_view_models/Edit/Settings/LoadSaveSongListViewModel.cpp
@@ -8,13 +8,11 @@ LoadSaveSongListViewModel::LoadSaveSongListViewModel(
     : deviceManager(dm), state(e.state.getOrCreateChildWithName(
                              IDs::LOAD_SAVE_SONG_VIEW_STATE, nullptr)),
       itemListState(state, songNames.size()) {
-
     auto userAppDataDirectory = juce::File::getSpecialLocation(
         juce::File::userApplicationDataDirectory);
     juce::File savedDirectory =
-        userAppDataDirectory.getChildFile(appName)
-            .getChildFile("saved");
-    
+        userAppDataDirectory.getChildFile(appName).getChildFile("saved");
+
     loadSongList(savedDirectory);
     itemListState.addListener(this);
 }
@@ -38,7 +36,7 @@ void LoadSaveSongListViewModel::selectedIndexChanged(int newIndex) {
 
 void LoadSaveSongListViewModel::loadSongList(const juce::File &directory) {
     songNames.clear();
-    songNames.add("Add");   
+    songNames.add("Add");
 
     juce::Array<juce::File> songFiles =
         directory.findChildFiles(juce::File::findFiles, false, "*.xml");

--- a/Source/Modules/app_view_models/Edit/Settings/LoadSaveSongListViewModel.h
+++ b/Source/Modules/app_view_models/Edit/Settings/LoadSaveSongListViewModel.h
@@ -2,8 +2,7 @@
 
 namespace app_view_models {
 namespace IDs {
-const juce::Identifier
-    LOAD_SAVE_SONG_VIEW_STATE("LOAD_SAVE_SONG_VIEW_STATE");
+const juce::Identifier LOAD_SAVE_SONG_VIEW_STATE("LOAD_SAVE_SONG_VIEW_STATE");
 }
 
 class LoadSaveSongListViewModel : private ItemListState::Listener {
@@ -14,8 +13,8 @@ class LoadSaveSongListViewModel : private ItemListState::Listener {
 
     juce::StringArray getItemNames();
     juce::String getSelectedItem();
-    //void updateDeviceManagerDeviceType();
-    //void loadSongList();
+    // void updateDeviceManagerDeviceType();
+    // void loadSongList();
 
   private:
     juce::AudioDeviceManager &deviceManager;
@@ -24,10 +23,11 @@ class LoadSaveSongListViewModel : private ItemListState::Listener {
 
     void selectedIndexChanged(int newIndex) override;
     void loadSongList(const juce::File &directory);
+
   public:
     // Must appear below the other variables since it needs to be initialized
     // last
-    //juce::StringArray deviceTypes;
+    // juce::StringArray deviceTypes;
     juce::StringArray songNames;
     ItemListState itemListState;
 };

--- a/Source/Modules/app_view_models/Edit/Settings/LoadSaveSongListViewModel.h
+++ b/Source/Modules/app_view_models/Edit/Settings/LoadSaveSongListViewModel.h
@@ -1,0 +1,35 @@
+#pragma once
+
+namespace app_view_models {
+namespace IDs {
+const juce::Identifier
+    LOAD_SAVE_SONG_VIEW_STATE("LOAD_SAVE_SONG_VIEW_STATE");
+}
+
+class LoadSaveSongListViewModel : private ItemListState::Listener {
+  public:
+    LoadSaveSongListViewModel(tracktion::Edit &e, juce::AudioDeviceManager &dm,
+                              const juce::String &appName);
+    ~LoadSaveSongListViewModel() override;
+
+    juce::StringArray getItemNames();
+    juce::String getSelectedItem();
+    //void updateDeviceManagerDeviceType();
+    //void loadSongList();
+
+  private:
+    juce::AudioDeviceManager &deviceManager;
+    juce::ValueTree state;
+    juce::String applicationName;
+
+    void selectedIndexChanged(int newIndex) override;
+    void loadSongList(const juce::File &directory);
+  public:
+    // Must appear below the other variables since it needs to be initialized
+    // last
+    //juce::StringArray deviceTypes;
+    juce::StringArray songNames;
+    ItemListState itemListState;
+};
+
+} // namespace app_view_models

--- a/Source/Modules/app_view_models/Edit/Settings/SettingsListViewModel.h
+++ b/Source/Modules/app_view_models/Edit/Settings/SettingsListViewModel.h
@@ -13,6 +13,7 @@ class SettingsListViewModel {
     juce::StringArray getItemNames();
     juce::String getSelectedItem();
 
+    const juce::String loadSaveTrackSettingName = "Load/Save track";
     const juce::String deviceTypeSettingName = "Device Type";
     const juce::String outputSettingName = "Output";
     const juce::String sampleRateSettingName = "Sample Rate";
@@ -23,9 +24,14 @@ class SettingsListViewModel {
     juce::AudioDeviceManager &deviceManager;
     juce::ValueTree state;
     juce::StringArray settingNames =
-        juce::StringArray(juce::Array<juce::String>(
-            {deviceTypeSettingName, outputSettingName, sampleRateSettingName,
-             audioBufferSizeSettingName, midiInputSettingName}));
+        juce::StringArray(juce::Array<juce::String>({
+            loadSaveTrackSettingName,
+            outputSettingName, 
+            deviceTypeSettingName,
+            sampleRateSettingName,
+            audioBufferSizeSettingName, 
+            midiInputSettingName,
+            }));
 
   public:
     // Must appear below the other variables since it needs to be initialized

--- a/Source/Modules/app_view_models/Edit/Settings/SettingsListViewModel.h
+++ b/Source/Modules/app_view_models/Edit/Settings/SettingsListViewModel.h
@@ -26,12 +26,12 @@ class SettingsListViewModel {
     juce::StringArray settingNames =
         juce::StringArray(juce::Array<juce::String>({
             loadSaveTrackSettingName,
-            outputSettingName, 
+            outputSettingName,
             deviceTypeSettingName,
             sampleRateSettingName,
-            audioBufferSizeSettingName, 
+            audioBufferSizeSettingName,
             midiInputSettingName,
-            }));
+        }));
 
   public:
     // Must appear below the other variables since it needs to be initialized

--- a/Source/Modules/app_view_models/Edit/Tracks/TracksListViewModel.cpp
+++ b/Source/Modules/app_view_models/Edit/Tracks/TracksListViewModel.cpp
@@ -194,9 +194,11 @@ TracksListViewModel::TracksViewType TracksListViewModel::getTracksViewType() {
 void TracksListViewModel::setTracksViewType(TracksViewType type) {
     tracksViewType.setValue(static_cast<int>(type), nullptr);
 }
-
 void TracksListViewModel::startRecording() {
     // ensure a selected track exists
+    
+    edit.clickTrackEnabled = true;
+
     if (auto selectedTrack = dynamic_cast<tracktion::AudioTrack *>(
             listViewModel.getSelectedItem())) {
         // only start recording if we currently arent recording
@@ -211,6 +213,8 @@ void TracksListViewModel::startRecording() {
 }
 
 void TracksListViewModel::startPlaying() {
+    edit.clickTrackEnabled = false;
+
     auto &transport = edit.getTransport();
 
     if (!transport.isPlaying()) {

--- a/Source/Modules/app_view_models/Edit/Tracks/TracksListViewModel.cpp
+++ b/Source/Modules/app_view_models/Edit/Tracks/TracksListViewModel.cpp
@@ -196,7 +196,7 @@ void TracksListViewModel::setTracksViewType(TracksViewType type) {
 }
 void TracksListViewModel::startRecording() {
     // ensure a selected track exists
-    
+
     edit.clickTrackEnabled = true;
 
     if (auto selectedTrack = dynamic_cast<tracktion::AudioTrack *>(

--- a/Source/Modules/app_view_models/app_view_models.cpp
+++ b/Source/Modules/app_view_models/app_view_models.cpp
@@ -63,6 +63,7 @@
 // Settings
 #include "Edit/Settings/SettingsListViewModel.cpp"
 #include "Edit/Settings/DeviceTypeListViewModel.cpp"
+#include "Edit/Settings/LoadSaveSongListViewModel.cpp"
 #include "Edit/Settings/OutputListViewModel.cpp"
 #include "Edit/Settings/SampleRateListViewModel.cpp"
 #include "Edit/Settings/AudioBufferSizeListViewModel.cpp"

--- a/Source/Modules/app_view_models/app_view_models.h
+++ b/Source/Modules/app_view_models/app_view_models.h
@@ -53,6 +53,7 @@ namespace app_view_models {
     class MixerTrackViewModel;
     class SettingsListViewModel;
     class DeviceTypeListViewModel;
+    class LoadSaveSongListViewModel;
     class OutputListViewModel;
     class SampleRateListViewModel;
     class AudioBufferSizeListViewModel;
@@ -134,6 +135,7 @@ namespace app_view_models {
 // Settings
 #include "Edit/Settings/SettingsListViewModel.h"
 #include "Edit/Settings/DeviceTypeListViewModel.h"
+#include "Edit/Settings/LoadSaveSongListViewModel.h"
 #include "Edit/Settings/OutputListViewModel.h"
 #include "Edit/Settings/SampleRateListViewModel.h"
 #include "Edit/Settings/AudioBufferSizeListViewModel.h"

--- a/Source/Views/Edit/EditTabBarView.cpp
+++ b/Source/Views/Edit/EditTabBarView.cpp
@@ -116,7 +116,7 @@ void EditTabBarView::tempoSettingsButtonReleased() {
     }
 }
 
-void EditTabBarView::saveButtonReleased() {
+/* void EditTabBarView::saveButtonReleased() {
     if (isShowing()) {
         juce::Logger::writeToLog("Saving edit ...");
         tracktion::EditFileOperations fileOperations(edit);
@@ -129,6 +129,49 @@ void EditTabBarView::saveButtonReleased() {
         messageBox.setVisible(true);
         startTimer(1000);
     }
+}*/
+
+
+void EditTabBarView::saveButtonReleased() {      
+
+    const auto track_name = ConfigurationHelpers::getSavedTrackName();
+    
+    //editFile.create();
+    tracktion::EditFileOperations fileOperations(edit);
+    auto userAppDataDirectory = juce::File::getSpecialLocation(
+        juce::File::userApplicationDataDirectory);
+
+    juce::File savedDirectory =
+        userAppDataDirectory.getChildFile(JUCE_APPLICATION_NAME_STRING)
+            .getChildFile("saved");
+
+
+     if (!savedDirectory.exists()) {
+        if (!savedDirectory.createDirectory()) {
+            juce::Logger::writeToLog("Error creating folder: " +
+                                     savedDirectory.getFullPathName());
+            return;
+        }
+    }
+
+     if (track_name.exists()) {
+        fileOperations.saveAs(track_name, true);
+    }    
+    auto saveFile = savedDirectory.getChildFile(track_name.getFileName());      
+    
+    if (track_name.copyFileTo(saveFile)) {
+        juce::Logger::writeToLog("Track copied to: " +
+                                 saveFile.getFullPathName());
+    } else {
+        juce::Logger::writeToLog("Error copying to: " +
+                                 saveFile.getFullPathName());
+    }
+
+    juce::Logger::writeToLog("Complete! (" + track_name.getFileNameWithoutExtension() + ")");
+    messageBox.setMessage("Complete! (" + track_name.getFileNameWithoutExtension() + ")");
+    resized();
+    messageBox.setVisible(true);
+    startTimer(1000);
 }
 
 void EditTabBarView::renderButtonReleased() {

--- a/Source/Views/Edit/EditTabBarView.cpp
+++ b/Source/Views/Edit/EditTabBarView.cpp
@@ -131,12 +131,10 @@ void EditTabBarView::tempoSettingsButtonReleased() {
     }
 }*/
 
-
-void EditTabBarView::saveButtonReleased() {      
-
+void EditTabBarView::saveButtonReleased() {
     const auto track_name = ConfigurationHelpers::getSavedTrackName();
-    
-    //editFile.create();
+
+    // editFile.create();
     tracktion::EditFileOperations fileOperations(edit);
     auto userAppDataDirectory = juce::File::getSpecialLocation(
         juce::File::userApplicationDataDirectory);
@@ -145,8 +143,7 @@ void EditTabBarView::saveButtonReleased() {
         userAppDataDirectory.getChildFile(JUCE_APPLICATION_NAME_STRING)
             .getChildFile("saved");
 
-
-     if (!savedDirectory.exists()) {
+    if (!savedDirectory.exists()) {
         if (!savedDirectory.createDirectory()) {
             juce::Logger::writeToLog("Error creating folder: " +
                                      savedDirectory.getFullPathName());
@@ -154,11 +151,11 @@ void EditTabBarView::saveButtonReleased() {
         }
     }
 
-     if (track_name.exists()) {
+    if (track_name.exists()) {
         fileOperations.saveAs(track_name, true);
-    }    
-    auto saveFile = savedDirectory.getChildFile(track_name.getFileName());      
-    
+    }
+    auto saveFile = savedDirectory.getChildFile(track_name.getFileName());
+
     if (track_name.copyFileTo(saveFile)) {
         juce::Logger::writeToLog("Track copied to: " +
                                  saveFile.getFullPathName());
@@ -167,8 +164,10 @@ void EditTabBarView::saveButtonReleased() {
                                  saveFile.getFullPathName());
     }
 
-    juce::Logger::writeToLog("Complete! (" + track_name.getFileNameWithoutExtension() + ")");
-    messageBox.setMessage("Complete! (" + track_name.getFileNameWithoutExtension() + ")");
+    juce::Logger::writeToLog("Complete! (" +
+                             track_name.getFileNameWithoutExtension() + ")");
+    messageBox.setMessage("Complete! (" +
+                          track_name.getFileNameWithoutExtension() + ")");
     resized();
     messageBox.setVisible(true);
     startTimer(1000);

--- a/Source/Views/Edit/EditTabBarView.h
+++ b/Source/Views/Edit/EditTabBarView.h
@@ -17,7 +17,6 @@ class EditTabBarView : public juce::TabbedComponent,
     ~EditTabBarView() override;
     void paint(juce::Graphics &) override;
     void resized() override;
-
     void tracksButtonReleased() override;
     void tempoSettingsButtonReleased() override;
     void saveButtonReleased() override;

--- a/Source/Views/Edit/Settings/LoadSaveSongListView.cpp
+++ b/Source/Views/Edit/Settings/LoadSaveSongListView.cpp
@@ -1,0 +1,277 @@
+#include "LoadSaveSongListView.h"
+#include <ExtendedUIBehaviour.h>
+#include <app_navigation/app_navigation.h>
+#include <tracktion_engine/tracktion_engine.h>
+
+LoadSaveSongListView::LoadSaveSongListView(
+    tracktion::Edit &e, juce::AudioDeviceManager &dm,
+    app_services::MidiCommandManager &mcm)
+    : edit(e), deviceManager(dm), midiCommandManager(mcm),     
+      editTabBarView(e, mcm), 
+      viewModel(e, deviceManager, ConfigurationHelpers::getApplicationName()),
+      titledList(viewModel.getItemNames(), "Song list",
+                 ListTitle::IconType::FONT_AWESOME,
+                 juce::String::charToString(0xf7d9)) {
+    viewModel.itemListState.addListener(this);
+    midiCommandManager.addListener(this);
+
+    addAndMakeVisible(titledList);
+}
+
+LoadSaveSongListView::~LoadSaveSongListView() {
+    midiCommandManager.removeListener(this);
+    viewModel.itemListState.removeListener(this);
+}
+
+void LoadSaveSongListView::paint(juce::Graphics &g) {
+    g.fillAll(
+        getLookAndFeel().findColour(juce::ResizableWindow::backgroundColourId));
+}
+
+void LoadSaveSongListView::resized() {
+    titledList.setBounds(getLocalBounds());
+    titledList.getListView().getListBox().scrollToEnsureRowIsOnscreen(
+        viewModel.itemListState.getSelectedItemIndex());
+}
+
+void LoadSaveSongListView::encoder1Increased() {
+    if (isShowing()) {
+        if (midiCommandManager.getFocusedComponent() == this) {
+            viewModel.itemListState.setSelectedItemIndex(
+                viewModel.itemListState.getSelectedItemIndex() + 1);
+        }
+    }
+}
+
+void LoadSaveSongListView::encoder1Decreased() {
+    if (isShowing()) {
+        if (midiCommandManager.getFocusedComponent() == this) {
+            viewModel.itemListState.setSelectedItemIndex(
+                viewModel.itemListState.getSelectedItemIndex() - 1);
+        }
+    }
+}
+
+void LoadSaveSongListView::encoder1ButtonReleased() {
+    if (isShowing()) {
+        const auto index = viewModel.itemListState.getSelectedItemIndex();
+        if (index == 0) { // Add
+            const auto i = index;
+            const auto loadFile = ConfigurationHelpers::getSavedTrackName();
+            const auto loadFileName = loadFile.getFileName();
+
+            auto userAppDataDirectory = juce::File::getSpecialLocation(
+                juce::File::userApplicationDataDirectory);
+
+            juce::File savedDirectory =
+                userAppDataDirectory.getChildFile(JUCE_APPLICATION_NAME_STRING)
+                    .getChildFile("saved");
+
+            juce::File loadprojectDirectory =
+                userAppDataDirectory.getChildFile(JUCE_APPLICATION_NAME_STRING)
+                    .getChildFile("load_project");
+
+            //mountname
+            auto currentTime = juce::Time::getCurrentTime();
+            auto day =
+                juce::String(currentTime.getDayOfMonth()).paddedLeft('0', 2);
+            auto month = juce::String(currentTime.getMonth() + 1)
+                             .paddedLeft('0', 2); // Meses son 0-based
+            auto year = juce::String(currentTime.getYear());
+            auto hours =
+                juce::String(currentTime.getHours()).paddedLeft('0', 2);
+            auto minutes =
+                juce::String(currentTime.getMinutes()).paddedLeft('0', 2);
+            auto seconds =
+                juce::String(currentTime.getSeconds()).paddedLeft('0', 2);
+
+            juce::String newEditFileName = "edit_" + day + month + year +
+                                           hours + minutes + seconds + ".xml";
+            //
+            auto saveFile = savedDirectory.getChildFile(loadFileName);           
+            
+            if (saveFile.existsAsFile()) {
+                loadFile.copyFileTo(savedDirectory);
+            } else {
+                if (savedDirectory.createDirectory()) {
+                    if (loadFile.moveFileTo(saveFile)) {
+                        juce::Logger::writeToLog(
+                            "Track copied to: " +
+                            saveFile.getFullPathName());
+                    } else {
+                        juce::Logger::writeToLog(
+                            "Error copy to: " +
+                            saveFile.getFullPathName());
+                    }
+                } else {
+                    juce::Logger::writeToLog(
+                        "Error create folder: " +
+                        loadprojectDirectory.getFullPathName());
+                }
+            }
+
+            if (loadprojectDirectory.exists()) {
+                auto files = loadprojectDirectory.findChildFiles(
+                    juce::File::findFiles, false);
+                for (auto& file : files) {
+                    file.deleteFile();
+                }
+            }
+
+            auto editFile = loadprojectDirectory.getChildFile(newEditFileName); 
+            editFile.create();
+
+            
+            tracktion::Engine &engine = *tracktion::Engine::getEngines()[0];
+            std::unique_ptr<tracktion::Edit> loadedEdit =
+                tracktion::loadEditFromFile(engine, saveFile);
+
+            /* bool success = loadedEdit->engine.getTemporaryFileManager()
+                               .getTempDirectory()
+                               .deleteRecursively();*/
+
+
+            restartApplication();          
+
+
+        } else { // Load
+            juce::String projectName = viewModel.getItemNames()[index];
+            juce::File projectDirectory =
+                juce::File::getSpecialLocation(
+                    juce::File::userApplicationDataDirectory)
+                    .getChildFile(JUCE_APPLICATION_NAME_STRING)
+                    .getChildFile("saved");
+
+            juce::File projectFile =
+                projectDirectory.getChildFile(projectName + ".xml");
+
+            if (projectFile.existsAsFile()) {
+                juce::Logger::writeToLog("Loading project: " + projectName);
+                loadTrackFromFile(projectFile);               
+                //mainWindow = nullptr; // (deletes our window)                
+            } else {
+                juce::Logger::writeToLog("Project file does not exist: " +
+                                         projectFile.getFullPathName());
+            }
+            restartApplication();
+            
+        }         
+    }
+}
+void LoadSaveSongListView::restartApplication() {
+  
+    juce::String appPath =
+        juce::File::getSpecialLocation(juce::File::currentExecutableFile)
+            .getFullPathName();
+
+   
+    juce::ChildProcess process;
+    if (process.start(appPath)) {
+     
+        juce::Time::waitForMillisecondCounter(juce::Time::getMillisecondCounter() + 5000);
+        juce::JUCEApplication::getInstance()->quit();
+
+
+       
+    } else {
+        juce::Logger::writeToLog("Error al intentar reiniciar la aplicación.");
+    }
+}
+//void LoadSaveSongListView::restartApplication() {
+////    juce::Logger::writeToLog("Wait 2 seconds.");
+////    // Esperar un breve momento para que la aplicación actual termine
+////    juce::Time::waitForMillisecondCounter(juce::Time::getMillisecondCounter() +
+////                                          2000);
+////
+////    // Obtener el nombre del ejecutable de la aplicación
+////    juce::String appPath =
+////        juce::File::getSpecialLocation(juce::File::currentExecutableFile)
+////            .getFullPathName();
+////
+////    juce::Logger::writeToLog("appPath: " + appPath);
+////
+////#if JUCE_MAC || JUCE_LINUX
+////    juce::Logger::writeToLog("Linux restart: " + appPath);
+////    juce::String scriptPath = "/home/pi/LMN_start.sh";
+////    juce::ChildProcess process;
+////    if (process.start("sh " + scriptPath)) {
+////        juce::Logger::writeToLog("Executed LMN_start.sh successfully.");
+////    } else {
+////        juce::Logger::writeToLog("Error starting LMN_start.sh.");
+////    }
+////#else
+////    juce::Logger::writeToLog("Windows restart: " + appPath);
+////    juce::ChildProcess process;
+////    if (process.start(appPath)) {
+////        //juce::JUCEApplication::initialise();
+////        juce::Logger::writeToLog("Application restarted successfully.");
+////    } else {
+////        juce::Logger::writeToLog(
+////            "Error attempting to restart the application.");
+////    }
+////#endif
+//    juce::JUCEApplication::getInstance()->quit();
+//    // Cierra la aplicación actual después de un breve retraso
+//    /* juce::Timer::callAfterDelay(
+//        100, [] { juce::JUCEApplication::getInstance()->quit(); });*/
+//}
+void LoadSaveSongListView::loadTrackFromFile(const juce::File &projectFile) {
+    if (projectFile.existsAsFile()) {
+        juce::Logger::writeToLog("Loading project: " +
+                                 projectFile.getFileName());
+
+        tracktion::Engine &engine = *tracktion::Engine::getEngines()[0];
+        std::unique_ptr<tracktion::Edit> loadedEdit =
+            tracktion::loadEditFromFile(engine, projectFile);
+
+        if (loadedEdit) {
+            auto userAppDataDirectory = juce::File::getSpecialLocation(
+                juce::File::userApplicationDataDirectory);
+
+            juce::File loadprojectDirectory =
+                userAppDataDirectory.getChildFile(JUCE_APPLICATION_NAME_STRING)
+                    .getChildFile("load_project");
+
+            if (loadprojectDirectory.exists() &&
+                loadprojectDirectory.isDirectory()) {
+                
+                juce::Array<juce::File> files;
+                loadprojectDirectory.findChildFiles(
+                    files, juce::File::findFilesAndDirectories, true);
+
+                for (const auto &file : files) {
+                    if (file.deleteRecursively()) {
+                        juce::Logger::writeToLog("Archivo eliminado: " +
+                                                 file.getFullPathName());
+                    } else {
+                        juce::Logger::writeToLog(
+                            "No se pudo eliminar el archivo: " +
+                            file.getFullPathName());
+                    }
+                } 
+            } else {
+                juce::Logger::writeToLog(
+                    "The directory does not exist or is not a directory.");
+            }   
+            
+            juce::String fileName = projectFile.getFileName();
+            juce::File destinationFile =
+                loadprojectDirectory.getChildFile(fileName);
+
+            if (!projectFile.copyFileTo(destinationFile)) {
+                juce::Logger::writeToLog("Error copy on load");
+            }
+            juce::Logger::writeToLog("Project loaded successfully.");
+        } else {
+            juce::Logger::writeToLog("Failed to load project.");
+        }
+    } else {
+        juce::Logger::writeToLog("Project file does not exist: " +
+                                 projectFile.getFullPathName());
+    }
+}
+
+void LoadSaveSongListView::selectedIndexChanged(int newIndex) {
+    titledList.getListView().getListBox().selectRow(newIndex);
+    sendLookAndFeelChange();
+}

--- a/Source/Views/Edit/Settings/LoadSaveSongListView.cpp
+++ b/Source/Views/Edit/Settings/LoadSaveSongListView.cpp
@@ -6,8 +6,8 @@
 LoadSaveSongListView::LoadSaveSongListView(
     tracktion::Edit &e, juce::AudioDeviceManager &dm,
     app_services::MidiCommandManager &mcm)
-    : edit(e), deviceManager(dm), midiCommandManager(mcm),     
-      editTabBarView(e, mcm), 
+    : edit(e), deviceManager(dm), midiCommandManager(mcm),
+      editTabBarView(e, mcm),
       viewModel(e, deviceManager, ConfigurationHelpers::getApplicationName()),
       titledList(viewModel.getItemNames(), "Song list",
                  ListTitle::IconType::FONT_AWESOME,
@@ -71,7 +71,7 @@ void LoadSaveSongListView::encoder1ButtonReleased() {
                 userAppDataDirectory.getChildFile(JUCE_APPLICATION_NAME_STRING)
                     .getChildFile("load_project");
 
-            //mountname
+            // mountname
             auto currentTime = juce::Time::getCurrentTime();
             auto day =
                 juce::String(currentTime.getDayOfMonth()).paddedLeft('0', 2);
@@ -88,20 +88,18 @@ void LoadSaveSongListView::encoder1ButtonReleased() {
             juce::String newEditFileName = "edit_" + day + month + year +
                                            hours + minutes + seconds + ".xml";
             //
-            auto saveFile = savedDirectory.getChildFile(loadFileName);           
-            
+            auto saveFile = savedDirectory.getChildFile(loadFileName);
+
             if (saveFile.existsAsFile()) {
                 loadFile.copyFileTo(savedDirectory);
             } else {
                 if (savedDirectory.createDirectory()) {
                     if (loadFile.moveFileTo(saveFile)) {
-                        juce::Logger::writeToLog(
-                            "Track copied to: " +
-                            saveFile.getFullPathName());
+                        juce::Logger::writeToLog("Track copied to: " +
+                                                 saveFile.getFullPathName());
                     } else {
-                        juce::Logger::writeToLog(
-                            "Error copy to: " +
-                            saveFile.getFullPathName());
+                        juce::Logger::writeToLog("Error copy to: " +
+                                                 saveFile.getFullPathName());
                     }
                 } else {
                     juce::Logger::writeToLog(
@@ -113,15 +111,14 @@ void LoadSaveSongListView::encoder1ButtonReleased() {
             if (loadprojectDirectory.exists()) {
                 auto files = loadprojectDirectory.findChildFiles(
                     juce::File::findFiles, false);
-                for (auto& file : files) {
+                for (auto &file : files) {
                     file.deleteFile();
                 }
             }
 
-            auto editFile = loadprojectDirectory.getChildFile(newEditFileName); 
+            auto editFile = loadprojectDirectory.getChildFile(newEditFileName);
             editFile.create();
 
-            
             tracktion::Engine &engine = *tracktion::Engine::getEngines()[0];
             std::unique_ptr<tracktion::Edit> loadedEdit =
                 tracktion::loadEditFromFile(engine, saveFile);
@@ -130,9 +127,7 @@ void LoadSaveSongListView::encoder1ButtonReleased() {
                                .getTempDirectory()
                                .deleteRecursively();*/
 
-
-            restartApplication();          
-
+            restartApplication();
 
         } else { // Load
             juce::String projectName = viewModel.getItemNames()[index];
@@ -147,40 +142,35 @@ void LoadSaveSongListView::encoder1ButtonReleased() {
 
             if (projectFile.existsAsFile()) {
                 juce::Logger::writeToLog("Loading project: " + projectName);
-                loadTrackFromFile(projectFile);               
-                //mainWindow = nullptr; // (deletes our window)                
+                loadTrackFromFile(projectFile);
+                // mainWindow = nullptr; // (deletes our window)
             } else {
                 juce::Logger::writeToLog("Project file does not exist: " +
                                          projectFile.getFullPathName());
             }
             restartApplication();
-            
-        }         
+        }
     }
 }
 void LoadSaveSongListView::restartApplication() {
-  
     juce::String appPath =
         juce::File::getSpecialLocation(juce::File::currentExecutableFile)
             .getFullPathName();
 
-   
     juce::ChildProcess process;
     if (process.start(appPath)) {
-     
-        juce::Time::waitForMillisecondCounter(juce::Time::getMillisecondCounter() + 5000);
+        juce::Time::waitForMillisecondCounter(
+            juce::Time::getMillisecondCounter() + 5000);
         juce::JUCEApplication::getInstance()->quit();
 
-
-       
     } else {
         juce::Logger::writeToLog("Error al intentar reiniciar la aplicación.");
     }
 }
-//void LoadSaveSongListView::restartApplication() {
+// void LoadSaveSongListView::restartApplication() {
 ////    juce::Logger::writeToLog("Wait 2 seconds.");
 ////    // Esperar un breve momento para que la aplicación actual termine
-////    juce::Time::waitForMillisecondCounter(juce::Time::getMillisecondCounter() +
+//// juce::Time::waitForMillisecondCounter(juce::Time::getMillisecondCounter() +
 ////                                          2000);
 ////
 ////    // Obtener el nombre del ejecutable de la aplicación
@@ -234,7 +224,6 @@ void LoadSaveSongListView::loadTrackFromFile(const juce::File &projectFile) {
 
             if (loadprojectDirectory.exists() &&
                 loadprojectDirectory.isDirectory()) {
-                
                 juce::Array<juce::File> files;
                 loadprojectDirectory.findChildFiles(
                     files, juce::File::findFilesAndDirectories, true);
@@ -248,12 +237,12 @@ void LoadSaveSongListView::loadTrackFromFile(const juce::File &projectFile) {
                             "No se pudo eliminar el archivo: " +
                             file.getFullPathName());
                     }
-                } 
+                }
             } else {
                 juce::Logger::writeToLog(
                     "The directory does not exist or is not a directory.");
-            }   
-            
+            }
+
             juce::String fileName = projectFile.getFileName();
             juce::File destinationFile =
                 loadprojectDirectory.getChildFile(fileName);

--- a/Source/Views/Edit/Settings/LoadSaveSongListView.h
+++ b/Source/Views/Edit/Settings/LoadSaveSongListView.h
@@ -1,7 +1,7 @@
 #pragma once
+#include "EditTabBarView.h"
 #include "LabelColour1LookAndFeel.h"
 #include "TitledListView.h"
-#include "EditTabBarView.h"
 #include <MessageBox.h>
 #include <app_services/app_services.h>
 #include <app_view_models/app_view_models.h>
@@ -25,6 +25,7 @@ class LoadSaveSongListView : public juce::Component,
     void selectedIndexChanged(int newIndex) override;
 
     void loadTrackFromFile(const juce::File &projectFile);
+
   private:
     tracktion::Edit &edit;
     std::unique_ptr<tracktion::Edit> editTemp;

--- a/Source/Views/Edit/Settings/LoadSaveSongListView.h
+++ b/Source/Views/Edit/Settings/LoadSaveSongListView.h
@@ -1,0 +1,38 @@
+#pragma once
+#include "LabelColour1LookAndFeel.h"
+#include "TitledListView.h"
+#include "EditTabBarView.h"
+#include <MessageBox.h>
+#include <app_services/app_services.h>
+#include <app_view_models/app_view_models.h>
+#include <juce_gui_extra/juce_gui_extra.h>
+#include <tracktion_engine/tracktion_engine.h>
+
+class LoadSaveSongListView : public juce::Component,
+                             public app_view_models::ItemListState::Listener,
+                             public app_services::MidiCommandManager::Listener {
+  public:
+    LoadSaveSongListView(tracktion::Edit &e, juce::AudioDeviceManager &dm,
+                         app_services::MidiCommandManager &mcm);
+    ~LoadSaveSongListView() override;
+    void paint(juce::Graphics &) override;
+    void resized() override;
+
+    void encoder1Increased() override;
+    void encoder1Decreased() override;
+    void encoder1ButtonReleased() override;
+    void restartApplication();
+    void selectedIndexChanged(int newIndex) override;
+
+    void loadTrackFromFile(const juce::File &projectFile);
+  private:
+    tracktion::Edit &edit;
+    std::unique_ptr<tracktion::Edit> editTemp;
+    juce::AudioDeviceManager &deviceManager;
+    app_services::MidiCommandManager &midiCommandManager;
+    app_view_models::LoadSaveSongListViewModel viewModel;
+    TitledListView titledList;
+    EditTabBarView editTabBarView;
+    MessageBox messageBox;
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(LoadSaveSongListView)
+};

--- a/Source/Views/Edit/Settings/SettingsListView.cpp
+++ b/Source/Views/Edit/Settings/SettingsListView.cpp
@@ -3,6 +3,7 @@
 #include "DeviceTypeListView.h"
 #include "MidiInputListView.h"
 #include "OutputListView.h"
+#include "LoadSaveSongListView.h"
 #include "SampleRateListView.h"
 #include <app_navigation/app_navigation.h>
 
@@ -70,10 +71,13 @@ void SettingsListView::encoder1ButtonReleased() {
                         edit, deviceManager, midiCommandManager));
                 } else if (selectedItem == viewModel.midiInputSettingName) {
                     stackNavigationController->push(new MidiInputListView(
+                        edit, deviceManager, midiCommandManager));                
+                } else if (selectedItem == viewModel.loadSaveTrackSettingName) {
+                    stackNavigationController->push(new LoadSaveSongListView(
                         edit, deviceManager, midiCommandManager));
                 } else {
-                    stackNavigationController->push(new AudioBufferSizeListView(
-                        edit, deviceManager, midiCommandManager));
+                        stackNavigationController->push(new AudioBufferSizeListView(
+                            edit, deviceManager, midiCommandManager));
                 }
                 midiCommandManager.setFocusedComponent(
                     stackNavigationController->getTopComponent());

--- a/Source/Views/Edit/Settings/SettingsListView.cpp
+++ b/Source/Views/Edit/Settings/SettingsListView.cpp
@@ -1,9 +1,9 @@
 #include "SettingsListView.h"
 #include "AudioBufferSizeListView.h"
 #include "DeviceTypeListView.h"
+#include "LoadSaveSongListView.h"
 #include "MidiInputListView.h"
 #include "OutputListView.h"
-#include "LoadSaveSongListView.h"
 #include "SampleRateListView.h"
 #include <app_navigation/app_navigation.h>
 
@@ -71,13 +71,13 @@ void SettingsListView::encoder1ButtonReleased() {
                         edit, deviceManager, midiCommandManager));
                 } else if (selectedItem == viewModel.midiInputSettingName) {
                     stackNavigationController->push(new MidiInputListView(
-                        edit, deviceManager, midiCommandManager));                
+                        edit, deviceManager, midiCommandManager));
                 } else if (selectedItem == viewModel.loadSaveTrackSettingName) {
                     stackNavigationController->push(new LoadSaveSongListView(
                         edit, deviceManager, midiCommandManager));
                 } else {
-                        stackNavigationController->push(new AudioBufferSizeListView(
-                            edit, deviceManager, midiCommandManager));
+                    stackNavigationController->push(new AudioBufferSizeListView(
+                        edit, deviceManager, midiCommandManager));
                 }
                 midiCommandManager.setFocusedComponent(
                     stackNavigationController->getTopComponent());

--- a/Source/Views/Edit/Tracks/TracksView.cpp
+++ b/Source/Views/Edit/Tracks/TracksView.cpp
@@ -487,5 +487,4 @@ void TracksView::noteOnPressed(int noteNumber) {
             }
         }
     }
-
 }

--- a/Source/Views/Edit/Tracks/TracksView.cpp
+++ b/Source/Views/Edit/Tracks/TracksView.cpp
@@ -451,3 +451,41 @@ void TracksView::undoButtonReleased() {
         if (midiCommandManager.getFocusedComponent() == this)
             viewModel.undo();
 }
+
+// CJM
+void TracksView::noteOnPressed(int noteNumber) {
+    juce::Logger::writeToLog("noteOnPressed  noteNumber" +
+                             std::to_string(noteNumber));
+    if (midiCommandManager.isPlusDown) {
+        juce::Logger::writeToLog("Ha entrado en el mute");
+
+        int trackIndex = -1;
+
+        switch (noteNumber) {
+        case 53:
+            trackIndex = 1;
+            break;
+        case 54:
+            trackIndex = 2;
+            break;
+        case 55:
+            trackIndex = 3;
+            break;
+        case 56:
+            trackIndex = 4;
+            break;
+        default:
+            break;
+        }
+        if (trackIndex != -1) {
+            // Verifica si el índice es válido
+            if (trackIndex < viewModel.listViewModel.itemListState.listSize) {
+                viewModel.listViewModel.itemListState.setSelectedItemIndex(
+                    trackIndex);
+                informationPanel.setIsMuted(
+                    viewModel.getSelectedTrackMuteState());
+            }
+        }
+    }
+
+}

--- a/Source/Views/Edit/Tracks/TracksView.h
+++ b/Source/Views/Edit/Tracks/TracksView.h
@@ -55,7 +55,9 @@ class TracksView : public juce::Component,
     void recordButtonReleased() override;
     void playButtonReleased() override;
     void stopButtonReleased() override;
-
+    
+    void noteOnPressed(int noteNumber) override;
+    
     // ItemListState listener methods
     void selectedIndexChanged(int newIndex) override;
 

--- a/Source/Views/Edit/Tracks/TracksView.h
+++ b/Source/Views/Edit/Tracks/TracksView.h
@@ -55,9 +55,9 @@ class TracksView : public juce::Component,
     void recordButtonReleased() override;
     void playButtonReleased() override;
     void stopButtonReleased() override;
-    
+
     void noteOnPressed(int noteNumber) override;
-    
+
     // ItemListState listener methods
     void selectedIndexChanged(int newIndex) override;
 


### PR DESCRIPTION
### 1. Description

Add “Load / Save” feature.

This is a clean history branch of the fork from @vidalsasun that can be merged into the official repository. You can see his work on his [repository](https://github.com/vidalsasun/LMN-3-DAW).

I'm not the author of this changes and I didn't make any change in the code (except linting format), the following is the details of his work:

**Screenshots**

![settings: display the load / save entry menu](https://github.com/vidalsasun/LMN-3-DAW/assets/23163594/7eabe772-995c-4199-ae2f-b5999457683c)

![Display the track list menu](https://github.com/vidalsasun/LMN-3-DAW/assets/23163594/0fc9b7a4-0d95-4af8-9a11-ab6e3a8f3648)

Since we do not have an alphabetical keyboard, I have decided to name the tracks with the format `edit_+ddmmyyyyhhMMss`. 

If you decide to change the file name later, it will load without any problem.

![display saved folder content on windows](https://github.com/vidalsasun/LMN-3-DAW/assets/23163594/45ec9ece-3594-42f7-93a2-b191dc9e8a48)
![display track list on lmn-daw](https://github.com/vidalsasun/LMN-3-DAW/assets/23163594/5a8cdfd5-ec5f-42e3-a554-8586018bbe9b)

There are 2 new folders on /home/pi/.config/LMN-3:
  -  Saved: where all tracks are stored
  -  load_project: the actual project

  When you press the save button:
    -  the load_project xml file is moved to saved folder, if there are a file whith the same name, it is overwriten
   
  When you Add a new track: 
    -  Load_project folder is cleaned 
    -  A new file is created on Load_project folder and the actual project xml file are moved to saved folder, if there are a file whith the same name, it is overwriten
    -  LMN-3 program restart

  When you load a track:
    -  Load_project folder is cleaned and the track selected is moved to load_project folder
    -  LMN-3 program restart    

When you save track, you can see the actual project name: 

![Display LMN-3 on save](https://github.com/vidalsasun/LMN-3-DAW/assets/23163594/2ad3a2b6-f615-4a18-816f-8fef433476d2)


### 2. Fill in checklist by marking [x]
- [x] I've read the CONTRIBUTING.md
- [x] My code is formatted using required linting
- [x] I've run my code locally and checked it works
- [x] My code has unit tests associated with it (if applicable)
- [x] I've run the test suite locally and all tests pass
